### PR TITLE
Handle spaces in deck names

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,9 @@ You may download this add-on by visiting [AnkiWeb](https://ankiweb.net/shared/in
 or by pasting the code `1172858842` into the Anki Add-on installation box
 through **Tools→Add-ons→Browse & Install**.
 
+By default, deck names with spaces are separated with dashes (`-`). This can be
+configured with the `SEPARATOR` variable at the top of the script.
+
 ## Reporting bugs
 
 To report bugs, visit the [GitHub issues](https://github.com/adelq/anki_hierarchy/issues)

--- a/anki_hierarchy.py
+++ b/anki_hierarchy.py
@@ -24,6 +24,8 @@ from aqt import mw
 from anki.utils import intTime, ids2str
 from aqt.qt import *
 
+SEPARATOR = "-"
+
 
 def convert_subdecks_to_tags():
     """Main function to convert currently selected deck."""
@@ -31,7 +33,8 @@ def convert_subdecks_to_tags():
     children_decks = mw.col.decks.children(parent_deck_id)
     mw.checkpoint(_("convert subdeck to tags"))
     for child_deck_name, child_deck_id in children_decks:
-        tag = child_deck_name
+        # Use dashes as word separators to avoid multiple tags
+        tag = child_deck_name.replace(" ", SEPARATOR)
 
         # Get old card properties
         child_cids = mw.col.decks.cids(child_deck_id)


### PR DESCRIPTION
Fixes issue #1. I found after browsing around that dashes are more frequently used as separators in tags than underscores. Thanks @glutanimate!